### PR TITLE
Added code to create replay buffers for behavioral cloning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+test_set_tuples
+train_set_tuples
+val_set_tuples
+test/*
+Pipfile
+Pipfile.lock
+

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The data used to develop, run and evaluate our experiments is extracted from the
 This extracted cohort is for general purpose use, for the usage in this paper it required additional preprocessing which we outline here.
 - Run `scripts/compute_acuity_scores.py` to compute additional acuity scores with the raw patient features.
 - Run `scripts/split_sepsis_cohort.py` to compose a training, validation and testing split as well as remove binary or demographic information from the temporal patient features. This script also organizes the patient data into convenient trajectory formats for easier use with sequential or recurrent models.
+- Run `scripts/create_buffers.py` to create replay buffers needed in the next step. Make sure to set the location where you want the resulting files to be saved in `configs/config_behavCloning.yaml`.
 - Use Behavior Cloning on the data provided by the previous step to develop a baseline "expert" policy for use in training and evaluating RL policies from the learned patient representations.
-  * This is done by running `scripts/train_behavCloning.py`. An example of how this can be done is provided in `slurm_scripts/slurm_build_BC.py` --> `slurm_scripts/slurm_bc_exp`.
+  * Two options are possible: Use either `scripts/train_behavCloning_with_config_file.py` if you want parameters to be loaded only from the config files, or `scripts/train_behavCloning_with_command_line_args.py` to use command line arguments. **Note, that in the second option, the parameters from the config files are overwritten by command line arguments, and if you don't specify command lines arguments then the default values for these arguments from the code will be used, not the values from the config files.** For the first option, the relevant configs are `configs/config_behavCloning.yaml` and `configs/common.yaml`. For the second option, an example of how this can be done is provided in `slurm_scripts/slurm_build_BC.py` --> `slurm_scripts/slurm_bc_exp`. 
   * This will generate either `behav_policy_file` or `behav_policy_file_wDemo` which is used internal to Steps 2 and 3 below.
 
 ### Step 2: Learning Representations

--- a/configs/common.yaml
+++ b/configs/common.yaml
@@ -1,4 +1,4 @@
-device: 'cuda'
+device: 'cpu' # or 'cuda'
 random_seed: 1234 # updated by run scripts
 folder_location: './results/'
 folder_name: 'test' # updated by run scripts
@@ -11,14 +11,15 @@ perception_neg_traj_ratio: 'NA'
 state_dim: 33                      
 num_actions: 25   
 context_dim: 5                     # Number of context/demographic/binary indicator variables we'll use as input
-
+dem_context: True
 
 # update these manually
 storage_path: '/scratch/hdd001/home/haoran/ml4h2020_srl_test/'
 
-train_data_file: '/scratch/hdd001/projects/ml4h/projects/srl_rl4h_tuples/new_train_set_tuples'
-validation_data_file: '/scratch/hdd001/projects/ml4h/projects/srl_rl4h_tuples/new_val_set_tuples'
-test_data_file: '/scratch/hdd001/projects/ml4h/projects/srl_rl4h_tuples/new_test_set_tuples'
+# where train, val and test tuples are
+train_data_file: '/path/rl_representations/data/train_set_tuples'
+validation_data_file: '/path/rl_representations/data/val_set_tuples'
+test_data_file: '/path/rl_representations/data/test_set_tuples'
 
 behav_policy_file_wDemo: '/scratch/ssd001/home/tkillian/ml4h2020_srl/BehavCloning/BC_l1e-5_n64_w0_sgd_withDemo/BC_model.pt'
 behav_policy_file: '/scratch/ssd001/home/tkillian/ml4h2020_srl/BehavCloning/BC_l1e-5_n64_w0_sgd/BC_model.pt'

--- a/configs/config_behavCloning.yaml
+++ b/configs/config_behavCloning.yaml
@@ -1,0 +1,15 @@
+num_nodes: 128
+hidden_size: 128 # num_nodes should be equal to hidden_size, it's the same but used in different places with different names
+
+learning_rate: 0.0001
+storage_folder: 'test/'
+batch_size: 128
+# num_epochs: 5000
+num_epochs: 1
+weight_decay: 0.1
+optim_type: 'adam'
+
+
+# where replay buffers should be
+train_buffer: '/path/rl_representations/data/replay_buffer_without_encoding/train_buffer'
+val_buffer: '/path/rl_representations/data/replay_buffer_without_encoding/val_buffer'

--- a/configs/config_behavCloning.yaml
+++ b/configs/config_behavCloning.yaml
@@ -4,8 +4,7 @@ hidden_size: 128 # num_nodes should be equal to hidden_size, it's the same but u
 learning_rate: 0.0001
 storage_folder: 'test/'
 batch_size: 128
-# num_epochs: 5000
-num_epochs: 1
+num_epochs: 5000
 weight_decay: 0.1
 optim_type: 'adam'
 

--- a/scripts/create_buffers.py
+++ b/scripts/create_buffers.py
@@ -1,0 +1,139 @@
+import yaml
+import os
+import sys
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+from utils import ReplayBuffer
+
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(ROOT_DIR)
+
+
+class Buffer(object):
+  def __init__(self, hidden_size, state_dim, context_dim, train_data_file, validation_data_file, batch_size, device, dem_context, train_buffer, val_buffer):
+        
+        self.hidden_size = hidden_size
+        self.minibatch_size = batch_size
+        self.state_dim = state_dim
+        self.context_dim = context_dim
+        self.train_data_file = train_data_file
+        self.validation_data_file = validation_data_file
+        self.context_input = dem_context
+        self.train_buffer = train_buffer
+        self.val_buffer = val_buffer
+
+        if device == 'cuda':
+            self.device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
+        elif device == 'cpu':
+            self.device = torch.device('cpu')
+        else:
+            print("Please set device to 'cuda' or 'cpu'")
+            exit(1)
+        print('Using device:', self.device)
+            
+
+  def create_buffers_and_save(self):
+        replay_buffer_train = ReplayBuffer(self.hidden_size, self.minibatch_size, 200000, self.device, encoded_state=False, obs_state_dim=self.state_dim + (self.context_dim if self.context_input else 0))
+        replay_buffer_val = ReplayBuffer(self.hidden_size, self.minibatch_size, 50000, self.device, encoded_state=False, obs_state_dim=self.state_dim + (self.context_dim if self.context_input else 0))
+        
+        self.train_demog, self.train_states, self.train_interventions, self.train_lengths, self.train_times, self.acuities, self.rewards = torch.load(self.train_data_file)
+        train_idx = torch.arange(self.train_demog.shape[0])
+        self.train_dataset = TensorDataset(self.train_demog, self.train_states, self.train_interventions,self.train_lengths,self.train_times, self.acuities, self.rewards, train_idx)
+        self.train_loader = DataLoader(self.train_dataset, batch_size=self.minibatch_size, shuffle=True)
+
+        self.val_demog, self.val_states, self.val_interventions, self.val_lengths, self.val_times, self.val_acuities, self.val_rewards = torch.load(self.validation_data_file)
+        val_idx = torch.arange(self.val_demog.shape[0])
+        self.val_dataset = TensorDataset(self.val_demog, self.val_states, self.val_interventions, self.val_lengths, self.val_times, self.val_acuities, self.val_rewards, val_idx)
+        self.val_loader = DataLoader(self.val_dataset, batch_size=self.minibatch_size, shuffle=False)
+
+        
+        all_loaders_list = [self.train_loader, self.val_loader]
+        all_buffers = [replay_buffer_train, replay_buffer_val]
+        all_buffers_save_files = [self.train_buffer, self.val_buffer]
+
+        for i_set, loader in enumerate(all_loaders_list):
+            print("Creating buffer for set ", i_set)
+            replay_buffer = all_buffers[i_set]
+            buffer_save_file = all_buffers_save_files[i_set]
+
+            for dem, ob, ac, l, t, scores, rewards, idx in loader:       
+                dem = dem.to(self.device)
+                ob = ob.to(self.device)
+                ac = ac.to(self.device)
+                l = l.to(self.device)
+                t = t.to(self.device)
+                scores = scores.to(self.device)
+                rewards = rewards.to(self.device)
+
+                max_length = int(l.max().item())
+
+                ob = ob[:,:max_length,:]
+                dem = dem[:,:max_length,:]
+                ac = ac[:,:max_length,:]
+                scores = scores[:,:max_length,:]
+                rewards = rewards[:,:max_length]
+
+                cur_obs, next_obs = ob[:,:-1,:], ob[:,1:,:]                
+                cur_dem, next_dem = dem[:,:-1,:], dem[:,1:,:]
+                cur_actions = ac[:,:-1,:]
+                cur_rewards = rewards[:,:-1]
+
+                mask = (cur_obs==0).all(dim=2)
+
+                cur_actions = cur_actions[~mask].cpu()
+                cur_rewards = cur_rewards[~mask].cpu()
+                cur_obs = cur_obs[~mask].cpu()
+                next_obs = next_obs[~mask].cpu()
+                cur_dem = cur_dem[~mask].cpu()
+                next_dem = next_dem[~mask].cpu()
+
+               
+                # Loop over all transitions and add them to the replay buffer
+                for i_trans in range(cur_obs.shape[0]):
+
+                    done = cur_rewards[i_trans] != 0
+                    
+                    if self.context_input:
+                        replay_buffer.add(torch.cat((cur_obs[i_trans],cur_dem[i_trans]),dim=-1).numpy(), cur_actions[i_trans].argmax().item(), torch.cat((next_obs[i_trans], next_dem[i_trans]), dim=-1).numpy(), cur_rewards[i_trans].item(), done.item())
+                    else:
+                        replay_buffer.add(cur_obs[i_trans].numpy(), cur_actions[i_trans].argmax().item(), next_obs[i_trans].numpy(), cur_rewards[i_trans].item(), done.item())
+
+
+            # Save the replay buffer
+            print("Saving buffer to ", buffer_save_file)
+            replay_buffer.save(buffer_save_file)
+           
+
+
+
+if __name__ == '__main__':
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    print(f"{dir_path=}")
+    behavCloning_params = yaml.safe_load(open(os.path.join(dir_path, '../configs/config_behavCloning.yaml'), 'r'))
+    common_params = yaml.safe_load(open(os.path.join(dir_path, '../configs/common.yaml'), 'r')) 
+
+    torch.manual_seed(common_params['random_seed'])
+
+    # Create folder if it does not exist
+    if not os.path.exists(behavCloning_params['train_buffer']):
+        os.makedirs(behavCloning_params['train_buffer'])
+
+    if not os.path.exists(behavCloning_params['val_buffer']):
+        os.makedirs(behavCloning_params['val_buffer'])
+
+    buffer = Buffer(
+        hidden_size = behavCloning_params['hidden_size'],
+        batch_size = behavCloning_params['batch_size'],
+        state_dim = common_params['state_dim'],
+        context_dim = common_params['context_dim'],
+        train_data_file = common_params['train_data_file'],
+        validation_data_file = common_params['validation_data_file'],
+        dem_context = common_params['dem_context'],
+        train_buffer = behavCloning_params['train_buffer'],
+        val_buffer = behavCloning_params['val_buffer'],
+        device = common_params['device'], 
+    )
+    
+    buffer.create_buffers_and_save()
+

--- a/scripts/dBCQ_utils.py
+++ b/scripts/dBCQ_utils.py
@@ -229,12 +229,12 @@ class discrete_BCQ(object):
 
 	def polyak_target_update(self):
 		for param, target_param in zip(self.Q.parameters(), self.Q_target.parameters()):
-		   target_param.data.copy_(self.tau * param.data + (1 - self.tau) * target_param.data)
+			target_param.data.copy_(self.tau * param.data + (1 - self.tau) * target_param.data)
 
 
 	def copy_target_update(self):
 		if self.iterations % self.target_update_frequency == 0:
-				self.Q_target.load_state_dict(self.Q.state_dict())
+			self.Q_target.load_state_dict(self.Q.state_dict())
 
 
 def train_dBCQ(replay_buffer, num_actions, state_dim, device, parameters, behav_pol, pol_eval_dataloader, is_demog):

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -239,12 +239,12 @@ class Experiment(object):
             epoch_loss = []
             print("Experiment: autoencoder {0}: training Epoch = ".format(self.autoencoder), epoch+1, 'out of', self.autoencoder_num_epochs, 'epochs')
 
-            # Loop through the data using the data loader
+            # Loop through all the train data using the data loader
             for ii, (dem, ob, ac, l, t, scores, rewards, idx) in enumerate(self.train_loader):
                 # print("Batch {}".format(ii),end='')
                 dem = dem.to(device)  # 5 dimensional vector (Gender, Ventilation status, Re-admission status, Age, Weight)
                 ob = ob.to(device)    # 33 dimensional vector (time varying measures)
-                ac = ac.to(device)
+                ac = ac.to(device) # actions
                 l = l.to(device)
                 t = t.to(device)
                 scores = scores.to(device)
@@ -258,8 +258,10 @@ class Experiment(object):
                 train_loss, dec_loss, inv_loss = 0, 0, 0
                 model_loss, recon_loss, forward_loss = 0, 0, 0                    
                     
+                # Set training mode (nn.Module.train()). It does not actually trains the model, but just sets the model to training mode.
                 self.gen.train()
                 self.pred.train()
+
                 ob = ob[:,:max_length,:]
                 dem = dem[:,:max_length,:]
                 ac = ac[:,:max_length,:]
@@ -280,6 +282,7 @@ class Experiment(object):
                     train_loss, dec_loss, inv_loss, model_loss, recon_loss, forward_loss, corr_loss, loss_pred = loss_pred
                     train_loss = forward_loss + self.inv_loss_coef*inv_loss + self.dec_loss_coef*dec_loss - self.corr_coeff_param*corr_loss.sum()
                     train_loss.backward()
+                    # Clipping gradients
                     torch.nn.utils.clip_grad_norm(self.all_params, self.max_grad_norm)
                     self.optimizer.step()
                     epoch_loss.append(loss_pred.detach().cpu().numpy())
@@ -559,3 +562,4 @@ class Experiment(object):
 
         # Run dBCQ_utils.train_dBCQ
         train_dBCQ(replay_buffer, self.num_actions, self.hidden_size, self.device, params, behav_pol, pol_eval_dataloader, self.context_input)
+

--- a/scripts/train_behavCloning_with_command_line_args.py
+++ b/scripts/train_behavCloning_with_command_line_args.py
@@ -71,8 +71,7 @@ def run(BC_network, train_dataloader, val_dataloader, num_epochs, storage_dir, l
 
 if __name__ == '__main__':
 
-    # Instead of the commented out code below, we use config files
-
+    
     # Define input arguments and parameters to override the ones in the config file
     parser = argparse.ArgumentParser()
     parser.add_argument('--demographics', dest='dem_context', default=True, action='store_true')

--- a/scripts/train_behavCloning_with_command_line_args.py
+++ b/scripts/train_behavCloning_with_command_line_args.py
@@ -1,0 +1,145 @@
+"""
+This script is used to develop a baseline policy using only the observed patient data via Behavior Cloning.
+
+This baseline policy is then used to truncate and guide evaluation of policies learned using dBCQ. It should only need to be
+run once for each unique cohort that one looks to learn a better treatment policy for.
+
+The patient cohort used and evaluated in the study this code was built for is defined at: https://github.com/microsoft/mimic_sepsis
+============================================================================================================================
+This code is provided under the MIT License and is meant to be helpful, but WITHOUT ANY WARRANTY;
+
+November 2020 by Taylor Killian and Haoran Zhang; University of Toronto + Vector Institute
+============================================================================================================================
+Notes:
+
+"""
+
+# IMPORTS
+import argparse
+import os
+import sys
+import numpy as np
+import yaml
+import torch
+import torch.nn as nn
+from torch.utils.data import TensorDataset, DataLoader
+
+from dBCQ_utils import BehaviorCloning
+from utils import ReplayBuffer
+
+
+def run(BC_network, train_dataloader, val_dataloader, num_epochs, storage_dir, loss_func, device):
+    # Construct training and validation loops
+    validation_losses = []
+    training_losses = []
+    training_iters = 0
+    eval_frequency = 100
+	
+    for i_epoch in range(num_epochs):
+        
+        train_loss = BC_network.train_epoch(train_dataloader)
+        training_losses.append(train_loss)
+
+        if i_epoch % eval_frequency == 0:
+            eval_errors = []
+            BC_network.model.eval()
+            with torch.no_grad():
+                for val_state, val_action in val_dataloader:
+                    val_state = val_state.to(device)
+                    val_action = val_action.to(device)
+                    pred_actions = BC_network.model(val_state)
+                    try:
+                        eval_loss = loss_func(pred_actions, val_action.flatten())
+                        eval_errors.append(eval_loss.item())
+                    except:
+                        print("LOL ERRORS")
+
+            mean_val_loss = np.mean(eval_errors)
+            validation_losses.append(mean_val_loss)
+            np.save(storage_dir+'validation_losses.npy', validation_losses)
+            np.save(storage_dir+'training_losses.npy', training_losses)
+
+            print(f"Training iterations: {i_epoch}, Validation Loss: {mean_val_loss}")
+            # Save off and store trained BC model
+            torch.save(BC_network.model.state_dict(), storage_dir+'BC_model.pt')
+
+            BC_network.model.train()
+    
+    print("Finished training Behavior Cloning model")
+    print('+='*30)
+
+
+if __name__ == '__main__':
+
+    # Instead of the commented out code below, we use config files
+
+    # Define input arguments and parameters to override the ones in the config file
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--demographics', dest='dem_context', default=True, action='store_true')
+    parser.add_argument('--num_nodes', dest='num_nodes', default=128, type=int)
+    parser.add_argument('--learning_rate', dest='learning_rate', default=1e-4, type=float)
+    parser.add_argument('--storage_folder', dest='storage_folder', default='test/', type=str)
+    parser.add_argument('--batch_size', dest='batch_size', default=128, type=int)
+    parser.add_argument('--num_epochs', dest='num_epochs', default=5000, type=int)
+    parser.add_argument('--weight_decay', dest='weight_decay', default=0.1, type=float)
+    parser.add_argument('--optimizer_type', dest='optim_type', default='adam', type=str)
+
+    args = parser.parse_args()
+
+    
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    print(f"{dir_path=}")
+    behavCloning_params = yaml.safe_load(open(os.path.join(dir_path, '../configs/config_behavCloning.yaml'), 'r'))
+    common_params = yaml.safe_load(open(os.path.join(dir_path, '../configs/common.yaml'), 'r')) 
+
+
+    # Overriding the parameters in the config file with the input arguments
+    behavCloning_params.update(vars(args))
+
+    
+
+    
+    # setting device on GPU if available, else CPU
+    if common_params['device'] == 'cuda':
+        device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
+    elif common_params['device'] == 'cpu':
+        device = torch.device('cpu')
+    else:
+        print("Please set device to 'cuda' or 'cpu'")
+        exit(1)
+
+    print('Using device:', device)
+    
+
+    input_dim = 38 if common_params["dem_context"] else 33
+    num_actions = 25
+
+    train_buffer_file = behavCloning_params['train_buffer']
+    validation_buffer_file = behavCloning_params['val_buffer']
+
+    # Storage folder name is imported from the config file
+    storage_dir = behavCloning_params['storage_folder']
+    if not os.path.exists(storage_dir):
+        os.mkdir(storage_dir)
+
+    # Initialize and load the training and validation buffers to populate dataloaders
+    train_buffer = ReplayBuffer(input_dim, behavCloning_params["batch_size"], 200000, device)
+    train_buffer.load(train_buffer_file)
+    states = train_buffer.state[:train_buffer.crt_size]
+    actions = train_buffer.action[:train_buffer.crt_size]
+    train_dataset = TensorDataset(torch.from_numpy(states).float(), torch.from_numpy(actions).long())
+    train_dataloader = DataLoader(train_dataset, batch_size=behavCloning_params["batch_size"], shuffle=True)
+    
+    val_buffer = ReplayBuffer(input_dim, behavCloning_params["batch_size"], 50000, device)
+    val_buffer.load(validation_buffer_file)
+    val_states = val_buffer.state[:val_buffer.crt_size]
+    val_actions = val_buffer.action[:val_buffer.crt_size]
+    val_dataset = TensorDataset(torch.from_numpy(val_states).float(), torch.from_numpy(val_actions).long())
+    val_dataloader = DataLoader(val_dataset, batch_size=behavCloning_params["batch_size"], shuffle=False)
+
+    # Initialize the BC network
+    BC_network = BehaviorCloning(input_dim, num_actions, behavCloning_params["num_nodes"], behavCloning_params["learning_rate"], behavCloning_params["weight_decay"], behavCloning_params["optim_type"], device)
+
+    loss_func = nn.CrossEntropyLoss()
+
+    run(BC_network, train_dataloader, val_dataloader, behavCloning_params["num_epochs"], storage_dir, loss_func, device)

--- a/scripts/train_behavCloning_with_config_file.py
+++ b/scripts/train_behavCloning_with_config_file.py
@@ -19,6 +19,7 @@ import argparse
 import os
 import sys
 import numpy as np
+import yaml
 import torch
 import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
@@ -27,7 +28,7 @@ from dBCQ_utils import BehaviorCloning
 from utils import ReplayBuffer
 
 
-def run(BC_network, train_dataloader, val_dataloader, num_epochs, storage_dir, loss_func):
+def run(BC_network, train_dataloader, val_dataloader, num_epochs, storage_dir, loss_func, device):
     # Construct training and validation loops
     validation_losses = []
     training_losses = []
@@ -44,8 +45,8 @@ def run(BC_network, train_dataloader, val_dataloader, num_epochs, storage_dir, l
             BC_network.model.eval()
             with torch.no_grad():
                 for val_state, val_action in val_dataloader:
-                    val_state = val_state.to(torch.device('cuda'))
-                    val_action = val_action.to(torch.device('cuda'))
+                    val_state = val_state.to(device)
+                    val_action = val_action.to(device)
                     pred_actions = BC_network.model(val_state)
                     try:
                         eval_loss = loss_func(pred_actions, val_action.flatten())
@@ -70,53 +71,53 @@ def run(BC_network, train_dataloader, val_dataloader, num_epochs, storage_dir, l
 
 if __name__ == '__main__':
 
-    # Define input arguments and parameters
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--demographics', dest='dem_context', default=False, action='store_true')
-    parser.add_argument('--num_nodes', dest='num_nodes', default=128, type=int)
-    parser.add_argument('--learning_rate', dest='learning_rate', default=1e-4, type=float)
-    parser.add_argument('--storage_folder', dest='storage_folder', default='test', type=str)
-    parser.add_argument('--batch_size', dest='batch_size', default=128, type=int)
-    parser.add_argument('--num_epochs', dest='num_epochs', default=5000, type=int)
-    parser.add_argument('--weight_decay', dest='weight_decay', default=0.1, type=float)
-    parser.add_argument('--optimizer_type', dest='optim_type', default='adam', type=str)
 
-    args = parser.parse_args()
-
-    device = torch.device('cuda')
-
-    input_dim = 38 if args.dem_context else 33
-    num_actions = 25
-    if args.dem_context:
-        train_buffer_file = '/scratch/ssd001/home/tkillian/ml4h2020_srl/raw_data_buffers/train_buffer' 
-        validation_buffer_file = '/scratch/ssd001/home/tkillian/ml4h2020_srl/raw_data_buffers/val_buffer'
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    print(f"{dir_path=}")
+    behavCloning_params = yaml.safe_load(open(os.path.join(dir_path, '../configs/config_behavCloning.yaml'), 'r'))
+    common_params = yaml.safe_load(open(os.path.join(dir_path, '../configs/common.yaml'), 'r')) 
+    
+    # setting device on GPU if available, else CPU
+    if common_params['device'] == 'cuda':
+        device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
+    elif common_params['device'] == 'cpu':
+        device = torch.device('cpu')
     else:
-        train_buffer_file = '/scratch/ssd001/home/tkillian/ml4h2020_srl/raw_data_buffers/train_noCntxt_buffer' 
-        validation_buffer_file = '/scratch/ssd001/home/tkillian/ml4h2020_srl/raw_data_buffers/val_noCntxt_buffer'
+        print("Please set device to 'cuda' or 'cpu'")
+        exit(1)
 
-    storage_dir = '/scratch/ssd001/home/tkillian/ml4h2020_srl/BehavCloning/' + args.storage_folder + '/'
+    print('Using device:', device)
+    
 
+    input_dim = 38 if common_params["dem_context"] else 33
+    num_actions = 25
+
+    train_buffer_file = behavCloning_params['train_buffer']
+    validation_buffer_file = behavCloning_params['val_buffer']
+
+    # Storage folder name is imported from the config file
+    storage_dir = behavCloning_params['storage_folder']
     if not os.path.exists(storage_dir):
         os.mkdir(storage_dir)
 
     # Initialize and load the training and validation buffers to populate dataloaders
-    train_buffer = ReplayBuffer(input_dim, args.batch_size, 200000, device)
+    train_buffer = ReplayBuffer(input_dim, behavCloning_params["batch_size"], 200000, device)
     train_buffer.load(train_buffer_file)
     states = train_buffer.state[:train_buffer.crt_size]
     actions = train_buffer.action[:train_buffer.crt_size]
     train_dataset = TensorDataset(torch.from_numpy(states).float(), torch.from_numpy(actions).long())
-    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=True)
+    train_dataloader = DataLoader(train_dataset, batch_size=behavCloning_params["batch_size"], shuffle=True)
     
-    val_buffer = ReplayBuffer(input_dim, args.batch_size, 50000, device)
+    val_buffer = ReplayBuffer(input_dim, behavCloning_params["batch_size"], 50000, device)
     val_buffer.load(validation_buffer_file)
     val_states = val_buffer.state[:val_buffer.crt_size]
     val_actions = val_buffer.action[:val_buffer.crt_size]
     val_dataset = TensorDataset(torch.from_numpy(val_states).float(), torch.from_numpy(val_actions).long())
-    val_dataloader = DataLoader(val_dataset, batch_size=args.batch_size, shuffle=False)
+    val_dataloader = DataLoader(val_dataset, batch_size=behavCloning_params["batch_size"], shuffle=False)
 
     # Initialize the BC network
-    BC_network = BehaviorCloning(input_dim, num_actions, args.num_nodes, args.learning_rate, args.weight_decay, args.optim_type, device)
+    BC_network = BehaviorCloning(input_dim, num_actions, behavCloning_params["num_nodes"], behavCloning_params["learning_rate"], behavCloning_params["weight_decay"], behavCloning_params["optim_type"], device)
 
     loss_func = nn.CrossEntropyLoss()
 
-    run(BC_network, train_dataloader, val_dataloader, args.num_epochs, storage_dir, loss_func)
+    run(BC_network, train_dataloader, val_dataloader, behavCloning_params["num_epochs"], storage_dir, loss_func, device)

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -47,10 +47,11 @@ def run(autoencoder, domain, options):
     if autoencoder == 'CDE':
         model_params['coefs_folder'] =  os.path.join(params['storage_path'], model_params['coefs_folder'])
             
+    # Iterating over the keys in model_params and replacing the values in params merging the two dictionaries
     for i in model_params:
         params[i] = model_params[i]        
 
-    # replacing params with command line options
+    # Overriding params from config file with command line options if provided
     for opt in options:
         print(opt)
         assert opt[0] in params
@@ -61,13 +62,19 @@ def run(autoencoder, domain, options):
             new_opt = dtype(opt[1])
         params[opt[0]] = new_opt
 
+    # Printing final parameters
     print('Parameters ')
     for key in params:
         print(key, params[key])
     print('=' * 30)
 
-    # process param keys and values to match input to Cortex
-    params['device'] = torch.device(params["device"])
+    
+    if params['device'] == 'cuda':
+        if torch.cuda.is_available():
+            params['device'] = torch.device('cuda')
+        else:
+            params['device'] = torch.device('cpu')
+
     random_seed = params['random_seed']
     np.random.seed(random_seed)
     torch.manual_seed(random_seed)
@@ -75,6 +82,7 @@ def run(autoencoder, domain, options):
     params['rng'] = random_state
     params['domain'] = domain
         
+    # Update foldername to the full path
     folder_name = params['storage_path'] + params['folder_location'] + params['folder_name']
     if not os.path.exists(folder_name):
         os.makedirs(folder_name)
@@ -82,6 +90,7 @@ def run(autoencoder, domain, options):
     
     torch.set_num_threads(torch.get_num_threads())
     
+    # Save model_params as a separate key in params also
     params[f'{autoencoder.lower()}_hypers'] = model_params # Cortex hyperparameter dictionaries 
     
     # Experiment

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -149,7 +149,6 @@ class ReplayBuffer(object):
 
         self.next_state = np.array(self.state)
         self.action = np.zeros((self.max_size, 1))
-        self.next_state = np.array(self.state)
         self.reward = np.zeros((self.max_size, 1))
         self.not_done = np.zeros((self.max_size, 1))
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -12,18 +12,14 @@ Notes:
 
 import logging
 import numpy as np
-from hashlib import sha1
 import pandas as pd
 import matplotlib as mpl
 mpl.use('Agg')
 import matplotlib.pyplot as plt
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
 import os
 from models.common import mask_from_lengths
 from torch.utils.data import DataLoader
-from models.NeuralCDE.metamodel import NeuralCDE
 import controldiffeq
 
 logger = logging.getLogger(__name__)
@@ -136,7 +132,7 @@ def load_cde_data(fold, dataset, path, context_input, device):
 
 # Generic replay buffer for standard gym tasks (adapted from https://github.com/sfujim/BCQ/blob/master/discrete_BCQ/utils.py)
 class ReplayBuffer(object):
-    def __init__(self, state_dim, batch_size, buffer_size, device, encoded_state=False, obs_state_dim=50):
+    def __init__(self, state_dim, batch_size, buffer_size, device, encoded_state=False, obs_state_dim=38):
         self.batch_size = batch_size
         self.max_size = int(buffer_size)
         self.device = device
@@ -144,8 +140,14 @@ class ReplayBuffer(object):
 
         self.ptr = 0
         self.crt_size = 0
+        # If not encoded state, we put the not encoded data to self.state, instaead of self.obs_state
+        if not encoded_state:
+            self.state = np.zeros((self.max_size, obs_state_dim))
+            
+        else:
+            self.state = np.zeros((self.max_size, state_dim))
 
-        self.state = np.zeros((self.max_size, state_dim))
+        self.next_state = np.array(self.state)
         self.action = np.zeros((self.max_size, 1))
         self.next_state = np.array(self.state)
         self.reward = np.zeros((self.max_size, 1))
@@ -164,6 +166,7 @@ class ReplayBuffer(object):
         self.not_done[self.ptr] = 1. - done
 
         if self.encoded_state:
+            # Saving the not-encoded observations for the state and next_state
             self.obs_state[self.ptr] = obs_state
             self.next_obs_state[self.ptr] = next_obs_state
 


### PR DESCRIPTION
- New script `scripts/create_buffers` to create and save replay buffers used in behavioral clonnning.
- The functionality from `scripts/train_behavCloning` is copied to two files `scripts/train_behavCloning_with_config_file.py` and `scripts/train_behavCloning_with_command_line_args.py`.  I described what is the difference in the modified `README.md`. In short: the command line version of the script uses command line args overriding the parameters from config files, while the config file version uses no command line arguments - only parameters from the config files.
- in ReplayBuffer class in `utils.py` the constructor is adapted to account for the dimensionality of not-encoded data.
- Minor comments to the code are added, some unused imports are removed